### PR TITLE
Accomodate users who don't have the default scene

### DIFF
--- a/procedural_city_generation/visualization/blenderize.py
+++ b/procedural_city_generation/visualization/blenderize.py
@@ -124,8 +124,14 @@ def setupscenery():
 	except:
 		pass
 		
-	bpy.data.lamps["Lamp"].type="SUN"
-
+	if bpy.data.objects.get("Camera") is None:
+	    bpy.ops.object.camera_add(view_align=True,location=(1.91961, -3.53902, 1.84546), rotation=(1.141, 1.56617e-08, 0.497))
+		
+	try:
+	    bpy.data.lamps["Lamp"].type="SUN"
+	except:
+	    bpy.ops.object.lamp_add(type='SUN', location=(4.076245, 4.076245, 4.076245))
+	    bpy.context.scene.objects['Sun'].name = 'Lamp'
 
 def main(points,triangles,polygons):
 	"""


### PR DESCRIPTION
Some Blender users modify their startup file, `setupscenery()` assumes there will be a default cube and lamp. Blender throws a KeyError if a lamp or an object named Lamp doesn't exist.
